### PR TITLE
Fixing using playdate glyphs

### DIFF
--- a/pdDialogue.lua
+++ b/pdDialogue.lua
@@ -420,7 +420,7 @@ function pdDialogueBox:drawBackground(x, y)
 end
 
 function pdDialogueBox:drawText(x, y, text)
-    gfx.setImageDrawMode(gfx.kDrawModeFillBlack)
+    gfx.setImageDrawMode(gfx.kDrawModeInverted)
     if self.font ~= nil then
         -- variable will be table if a font family
         if type(self.font) == "table" then

--- a/pdDialogue.lua
+++ b/pdDialogue.lua
@@ -207,7 +207,7 @@ pdDialogueBox = {}
 class("pdDialogueBox").extends()
 
 function pdDialogueBox.buttonPrompt(x, y)
-    gfx.setImageDrawMode(gfx.kDrawModeFillBlack)
+    gfx.setImageDrawMode(gfx.kDrawModeCopy)
     gfx.getSystemFont():drawText("Ⓐ", x, y)
 end
 

--- a/pdDialogue.lua
+++ b/pdDialogue.lua
@@ -420,7 +420,7 @@ function pdDialogueBox:drawBackground(x, y)
 end
 
 function pdDialogueBox:drawText(x, y, text)
-    gfx.setImageDrawMode(gfx.kDrawModeInverted)
+    gfx.setImageDrawMode(gfx.kDrawModeCopy)
     if self.font ~= nil then
         -- variable will be table if a font family
         if type(self.font) == "table" then


### PR DESCRIPTION
I'm fairly sure you meant to use kDrawModeCopy instead of kDrawModeFillBlack to draw text

This is how it looks with the way it is now, with kDrawModeFillBlack:

![image](https://github.com/PizzaFuel/pdDialogue/assets/30127664/205a8b3c-6fc5-4ef5-8c36-091bca855e4d)

With kDrawModeCopy , playdate glyphs can be displayed properly

![image](https://github.com/PizzaFuel/pdDialogue/assets/30127664/0720fee5-1221-49ae-a6fe-c4d433bd98a0)

